### PR TITLE
feat: Implement Add Shoe screen

### DIFF
--- a/src/navigation/AppNavigator.js
+++ b/src/navigation/AppNavigator.js
@@ -9,6 +9,7 @@ import ShoeListScreen from '../screens/ShoeListScreen';
 import ShoeDetailScreen from '../screens/ShoeDetailScreen';
 import RetiredShoesReportScreen from '../screens/RetiredShoesReportScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import AddShoeScreen from '../screens/AddShoeScreen'; // Added import
 
 const Stack = createNativeStackNavigator();
 
@@ -50,6 +51,11 @@ const AppNavigator = () => {
         name="ShoeDetail" 
         component={ShoeDetailScreen} 
         options={{ title: 'Shoe Details' }} 
+      />
+      <Stack.Screen
+        name="AddShoe" // Added Screen
+        component={AddShoeScreen}
+        options={{ title: 'Add New Shoe' }}
       />
       <Stack.Screen 
         name="RetiredShoesReport" 

--- a/src/screens/AddShoeScreen.js
+++ b/src/screens/AddShoeScreen.js
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, StyleSheet, ScrollView, Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import Button from '../components/ui/Button';
+import { useTheme } from '../theme/ThemeProvider';
+import { useStore } from '../stores/useStore'; // Added
+
+const AddShoeScreen = () => {
+  const navigation = useNavigation();
+  const theme = useTheme();
+  const addShoe = useStore(state => state.addShoe); // Added
+
+  const [name, setName] = useState('');
+  const [brand, setBrand] = useState('');
+  const [model, setModel] = useState('');
+  const [purchaseDate, setPurchaseDate] = useState(new Date().toISOString().split('T')[0]);
+  const [maxDistance, setMaxDistance] = useState('');
+
+  const handleSave = () => {
+    if (!name.trim()) {
+      Alert.alert('Validation Error', 'Shoe name is required.');
+      return;
+    }
+    // Consider adding validation for purchaseDate format if necessary
+    if (maxDistance && (isNaN(parseFloat(maxDistance)) || parseFloat(maxDistance) < 0)) {
+      Alert.alert('Validation Error', 'Max distance must be a valid positive number.');
+      return;
+    }
+
+    const shoeData = {
+      name: name.trim(),
+      brand: brand.trim(),
+      model: model.trim(),
+      purchaseDate, // Ensure this is in ISOString format if the store expects that
+      maxDistance: maxDistance ? parseFloat(maxDistance) : 0,
+      // isActive: true, // The addShoe function in shoeStore already defaults this
+      // createdAt: new Date().toISOString(), // Store handles this
+      // updatedAt: new Date().toISOString(), // Store handles this
+    };
+
+    try {
+      addShoe(shoeData);
+      // Alert.alert('Success', 'Shoe added successfully!'); // Optional: show success message
+      navigation.goBack(); // Navigate back to the previous screen (likely ShoeListScreen)
+    } catch (error) {
+      console.error('Failed to save shoe:', error);
+      Alert.alert('Error', 'Failed to save shoe. Please try again.');
+    }
+  };
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    scrollView: {
+      flexGrow: 1,
+    },
+    content: {
+      padding: theme.spacing.md,
+    },
+    title: {
+      ...(theme.typography.h2 || { fontSize: 22, fontWeight: 'bold' }),
+      color: theme.colors.text.primary,
+      marginBottom: theme.spacing.lg,
+      textAlign: 'center',
+    },
+    input: {
+      backgroundColor: theme.colors.surface || theme.colors.card,
+      color: theme.colors.text.primary,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: theme.borderRadius.md || 8,
+      padding: theme.spacing.md,
+      marginBottom: theme.spacing.md,
+      fontSize: 16,
+    },
+    label: {
+      ...(theme.typography.label || { fontSize: 14, fontWeight: '600' }),
+      color: theme.colors.text.secondary,
+      marginBottom: theme.spacing.xs,
+    },
+    buttonContainer: {
+      marginTop: theme.spacing.lg,
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollView}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Add New Shoe</Text>
+
+          <Text style={styles.label}>Name*</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., Pegasus 40, Clifton 9"
+            value={name}
+            onChangeText={setName}
+            placeholderTextColor={theme.colors.text.hint || '#999999'}
+          />
+
+          <Text style={styles.label}>Brand</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., Nike, Hoka"
+            value={brand}
+            onChangeText={setBrand}
+            placeholderTextColor={theme.colors.text.hint || '#999999'}
+          />
+
+          <Text style={styles.label}>Model</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., Pegasus, Clifton"
+            value={model}
+            onChangeText={setModel}
+            placeholderTextColor={theme.colors.text.hint || '#999999'}
+          />
+
+          <Text style={styles.label}>Purchase Date</Text>
+          <TextInput
+            style={styles.input}
+            value={purchaseDate}
+            onChangeText={setPurchaseDate}
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor={theme.colors.text.hint || '#999999'}
+          />
+
+          <Text style={styles.label}>Max Distance (km)</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., 800"
+            value={maxDistance}
+            onChangeText={setMaxDistance}
+            keyboardType="numeric"
+            placeholderTextColor={theme.colors.text.hint || '#999999'}
+          />
+
+          <View style={styles.buttonContainer}>
+            <Button
+              title="Cancel"
+              onPress={() => navigation.goBack()}
+              variant="outline"
+              style={{flex: 1, marginRight: theme.spacing.sm || 8}}
+            />
+            <Button
+              title="Save Shoe"
+              onPress={handleSave}
+              variant="primary"
+              style={{flex: 1, marginLeft: theme.spacing.sm || 8}}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+export default AddShoeScreen;

--- a/src/screens/AddShoeScreen.test.js
+++ b/src/screens/AddShoeScreen.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import AddShoeScreen from './AddShoeScreen';
+
+// Mock navigation
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: mockGoBack,
+    navigate: mockNavigate,
+  }),
+}));
+
+// Mock store
+const mockAddShoe = jest.fn();
+jest.mock('../stores/useStore', () => ({
+  useStore: (selector) => selector({ addShoe: mockAddShoe }),
+}));
+
+// Mock theme
+jest.mock('../theme/ThemeProvider', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      text: { primary: '#000', secondary: '#555', hint: '#999' },
+      border: '#ccc',
+      surface: '#eee',
+      card: '#f8f8f8',
+    },
+    spacing: { xs: 4, sm: 8, md: 16, lg: 24 },
+    typography: { h2: {}, label: {} },
+    borderRadius: { md: 8 },
+  }),
+}));
+
+// Mock Alert
+global.Alert = {
+  alert: jest.fn(),
+};
+
+
+describe('AddShoeScreen', () => {
+  beforeEach(() => {
+    // Clear mocks before each test
+    mockAddShoe.mockClear();
+    mockGoBack.mockClear();
+    global.Alert.alert.mockClear();
+  });
+
+  it('renders all input fields and buttons', () => {
+    const { getByPlaceholderText, getByText } = render(<AddShoeScreen />);
+
+    expect(getByPlaceholderText('e.g., Pegasus 40, Clifton 9')).toBeTruthy(); // Name
+    expect(getByPlaceholderText('e.g., Nike, Hoka')).toBeTruthy(); // Brand
+    expect(getByPlaceholderText('e.g., Pegasus, Clifton')).toBeTruthy(); // Model
+    expect(getByPlaceholderText('YYYY-MM-DD')).toBeTruthy(); // Purchase Date
+    expect(getByPlaceholderText('e.g., 800')).toBeTruthy(); // Max Distance
+    expect(getByText('Save Shoe')).toBeTruthy();
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('updates input fields on change', () => {
+    const { getByPlaceholderText } = render(<AddShoeScreen />);
+    const nameInput = getByPlaceholderText('e.g., Pegasus 40, Clifton 9');
+    fireEvent.changeText(nameInput, 'Test Shoe');
+    expect(nameInput.props.value).toBe('Test Shoe');
+
+    const brandInput = getByPlaceholderText('e.g., Nike, Hoka');
+    fireEvent.changeText(brandInput, 'Test Brand');
+    expect(brandInput.props.value).toBe('Test Brand');
+  });
+
+  it('shows validation error if name is empty on save', () => {
+    const { getByText } = render(<AddShoeScreen />);
+    fireEvent.press(getByText('Save Shoe'));
+    expect(global.Alert.alert).toHaveBeenCalledWith('Validation Error', 'Shoe name is required.');
+    expect(mockAddShoe).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error if max distance is invalid on save', () => {
+    const { getByText, getByPlaceholderText } = render(<AddShoeScreen />);
+    const nameInput = getByPlaceholderText('e.g., Pegasus 40, Clifton 9');
+    fireEvent.changeText(nameInput, 'Test Shoe');
+    const maxDistanceInput = getByPlaceholderText('e.g., 800');
+    fireEvent.changeText(maxDistanceInput, 'abc'); // Invalid distance
+    fireEvent.press(getByText('Save Shoe'));
+    expect(global.Alert.alert).toHaveBeenCalledWith('Validation Error', 'Max distance must be a valid positive number.');
+    expect(mockAddShoe).not.toHaveBeenCalled();
+  });
+
+  it('calls addShoe and navigates back on successful save', async () => {
+    const { getByPlaceholderText, getByText } = render(<AddShoeScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('e.g., Pegasus 40, Clifton 9'), 'Victory');
+    fireEvent.changeText(getByPlaceholderText('e.g., Nike, Hoka'), 'Nike');
+    fireEvent.changeText(getByPlaceholderText('e.g., Pegasus, Clifton'), 'Alphafly 3');
+    const today = new Date().toISOString().split('T')[0];
+    fireEvent.changeText(getByPlaceholderText('YYYY-MM-DD'), today);
+    fireEvent.changeText(getByPlaceholderText('e.g., 800'), '600');
+
+    fireEvent.press(getByText('Save Shoe'));
+
+    await waitFor(() => {
+      expect(mockAddShoe).toHaveBeenCalledTimes(1);
+      expect(mockAddShoe).toHaveBeenCalledWith({
+        name: 'Victory',
+        brand: 'Nike',
+        model: 'Alphafly 3',
+        purchaseDate: today,
+        maxDistance: 600,
+      });
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('navigates back when cancel is pressed', () => {
+    const { getByText } = render(<AddShoeScreen />);
+    fireEvent.press(getByText('Cancel'));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This commit introduces the "Add Shoe" screen, allowing you to input details for new running shoes.

Key changes:
- Created `src/screens/AddShoeScreen.js` with a form including fields for name, brand, model, purchase date, and maximum distance.
- Integrated the form with `shoeStore.js` to save new shoe entries.
- Added validation for required fields (name) and valid input (max distance).
- Added `AddShoeScreen` to the main navigation stack in `AppNavigator.js`, making it accessible from the "My Shoes" screen.
- Included a basic set of unit tests for `AddShoeScreen.js` using `@testing-library/react-native` to cover rendering, input handling, validation, and submission logic.