### PR TITLE
Fix: Resolve infinite loop on ShoeDetailScreen and correct edit navig…

### DIFF
--- a/src/screens/ShoeDetailScreen.js
+++ b/src/screens/ShoeDetailScreen.js
@@ -163,27 +163,27 @@ const ShoeDetailScreen = ({ route, navigation }) => {
 
       {/* Logic using shoeWithDetails.isActive */}
       {!showRetirementForm && shoeWithDetails.isActive && (
-      {/* Edit Button */}
-      {!showRetirementForm && (
-        <Button
-          title="Edit Shoe Details"
-          onPress={() => navigation.navigate('EditShoe', { shoeId: shoe.id })}
-          variant="outline" // Or choose another appropriate variant
-          icon="edit" // Using MaterialIcons name
-          style={styles.actionButton}
-        />
-      )}
-
-      {!showRetirementForm && shoe.isActive && (
-        <Button
-          title="Retire Shoes"
-          onPress={() => setShowRetirementForm(true)}
-          variant="danger"
-          icon="flag"
-          style={styles.actionButton}
-        />
+        <>
+          {/* Edit Button */}
+          <Button
+            title="Edit Shoe Details"
+            onPress={() => navigation.navigate('EditShoe', { shoeId: shoeWithDetails.id })}
+            variant="outline" // Or choose another appropriate variant
+            icon="edit" // Using MaterialIcons name
+            style={styles.actionButton}
+          />
+          {/* Retire Button */}
+          <Button
+            title="Retire Shoes"
+            onPress={() => setShowRetirementForm(true)}
+            variant="danger"
+            icon="flag"
+            style={styles.actionButton}
+          />
+        </>
       )}
       
+      {/* This is the reactivate button, should be outside the isActive block */}
       {!showRetirementForm && !shoeWithDetails.isActive && (
         <Button
           title="Reactivate Shoes"

--- a/src/stores/shoeStore.js
+++ b/src/stores/shoeStore.js
@@ -2,6 +2,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { format, subMonths, startOfMonth, endOfMonth, eachDayOfInterval, isWithinInterval } from 'date-fns';
 import { saveData, loadData } from '../services/storage';
 
+const EMPTY_SHOE_USAGE = Object.freeze({ total: 0, monthly: {} });
+
 // Storage keys
 const STORAGE_KEYS = {
   RUNS: '@StrideSync:runs',
@@ -116,10 +118,9 @@ export const createShoeStore = (set, get) => ({
   },
   
   // Get shoe usage statistics
-  getShoeUsage: (shoeId) => {
-    const { shoeUsage } = get();
-    return shoeUsage[shoeId] || { total: 0, monthly: {} };
-  },
+  getShoeUsage: memoized('getShoeUsage', (shoeId) => {
+    return get().shoeUsage[shoeId] || EMPTY_SHOE_USAGE;
+  }),
   
   // Get comprehensive shoe statistics
   // CHANGED: Applied memoized decorator
@@ -680,7 +681,7 @@ export const createShoeStore = (set, get) => ({
   },
 
   // Selectors
-  getShoeById: (id) => {
+  getShoeById: memoized('getShoeById', (id) => {
     const shoe = get().shoes.find((shoe) => shoe.id === id);
     if (!shoe) return null;
     


### PR DESCRIPTION
…ation

This commit addresses two issues:

1.  An infinite re-render loop on the ShoeDetailScreen, identified by warnings "The result of getSnapshot should be cached" and "Maximum update depth exceeded." This was caused by the `getShoeById` selector in `shoeStore.js` returning a new object reference on every call, even if the underlying data hadn't changed.
    -   I memoized `getShoeById` using the existing `memoized` utility in `shoeStore.js`.
    -   I memoized `getShoeUsage` and ensured it returns a stable reference for empty usage data.
    These changes ensure that the selector returns the same object reference if the underlying data is unchanged within the cache TTL, preventing unnecessary re-renders.

2.  A bug where the "Edit Shoe Details" button on `ShoeDetailScreen.js` would cause an error because it tried to access `shoe.id` instead of `shoeWithDetails.id`.
    -   I corrected the navigation parameters to use `shoeWithDetails.id`.
    -   Additionally, I cleaned up some redundant conditional rendering logic for action buttons on this screen.