### PR TITLE
Fix: Ensure all screens respect unit settings (km/mi)

### DIFF
--- a/src/components/run_tracking/StatsDisplay.js
+++ b/src/components/run_tracking/StatsDisplay.js
@@ -2,18 +2,37 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { formatDuration } from '../../utils/formatters';
 import { useTheme } from '@react-navigation/native';
+import { useUnits } from '../../hooks/useUnits'; // Import useUnits
 
-const StatsDisplay = ({ distance = 0, duration = 0 }) => {
+const StatsDisplay = ({ distance = 0, duration = 0 }) => { // distance is always in km
   const { colors } = useTheme();
+  const { formatDistance, distanceUnit, fromKilometers } = useUnits();
 
-  // Pace in minutes per km
-  const pace = distance > 0 ? duration / 60 / distance : null;
-  const paceText = pace ? `${pace.toFixed(2)} min/km` : '--:-- min/km';
+  const displayDistance = formatDistance(distance); // Formats based on user's unit preference
+
+  let paceText = '--:--';
+  const currentDistanceUnitLabel = distanceUnit === 'mi' ? 'min/mi' : 'min/km';
+
+  if (distance > 0 && duration > 0) {
+    let distanceForPaceCalc = distance; // km
+    if (distanceUnit === 'mi') {
+      distanceForPaceCalc = fromKilometers(distance, 'mi'); // Convert to miles for pace calculation
+    }
+
+    if (distanceForPaceCalc > 0) { // Avoid division by zero if conversion results in very small number rounding to 0
+        const pace = duration / 60 / distanceForPaceCalc; // pace in minutes per preferred unit
+        const paceMinutes = Math.floor(pace);
+        const paceSeconds = Math.round((pace - paceMinutes) * 60);
+        paceText = `${paceMinutes}:${paceSeconds.toString().padStart(2, '0')}`;
+    }
+  }
+  paceText = `${paceText} ${currentDistanceUnitLabel}`;
+
 
   return (
     <View style={[styles.statsDisplay, { backgroundColor: colors.surface }]}>
       <Text style={[styles.statText, { color: colors.text.primary }]}>
-        Distance: {distance.toFixed(2)} km
+        Distance: {displayDistance.formatted}
       </Text>
       <Text style={[styles.statText, { color: colors.text.primary }]}>
         Duration: {formatDuration(duration)}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -184,12 +184,26 @@ const HomeScreen = ({ navigation }) => {
     },
   });
 
-  const renderRunItem = run => {
-    const formattedDistance = formatDistance(run.distance || 0);
-    const formattedPace =
-      run.pace && run.distance
-        ? `${run.pace.minutes}:${run.pace.seconds.toString().padStart(2, '0')}/${formattedDistance.unit}`
-        : '--:--';
+  const renderRunItem = run => { // run.distance is in km, run.pace is in seconds per km
+    const formattedDistance = formatDistance(run.distance || 0); // .value, .unit, .formatted
+
+    let displayPace = '--:--';
+    // Assuming run.pace is total seconds per km, as per models/runData.js
+    const totalSecondsPerKm = run.pace;
+
+    if (totalSecondsPerKm > 0 && run.distance > 0) {
+      let paceInSecondsPreferredUnit = totalSecondsPerKm;
+      if (formattedDistance.unit === 'mi') {
+        // Convert pace from sec/km to sec/mile
+        // 1 km = 0.621371 miles. X sec/km * (1 km / 0.621371 mi) = X / 0.621371 sec/mi
+        const KM_TO_MI = 0.621371; // Duplicating constant, consider centralizing if used more
+        paceInSecondsPreferredUnit = totalSecondsPerKm / KM_TO_MI;
+      }
+      const paceMinutes = Math.floor(paceInSecondsPreferredUnit / 60);
+      const paceSeconds = Math.round(paceInSecondsPreferredUnit % 60);
+      displayPace = `${paceMinutes}:${paceSeconds.toString().padStart(2, '0')}`;
+    }
+    displayPace = `${displayPace}/${formattedDistance.unit}`;
 
     return (
       <TouchableOpacity

--- a/src/screens/RetiredShoesReportScreen.js
+++ b/src/screens/RetiredShoesReportScreen.js
@@ -7,9 +7,11 @@ import { MaterialIcons } from '@expo/vector-icons';
 import Card from '../components/ui/Card';
 import StatsCard from '../components/StatsCard';
 import ShoeListItem from '../components/ShoeListItem';
+import { useUnits } from '../hooks/useUnits'; // Import useUnits
 
 const RetiredShoesReportScreen = ({ navigation }) => {
   const theme = useTheme();
+  const { formatDistance } = useUnits(); // Call useUnits
   const shoes = useStore(state => state.shoes);
   const getShoeStats = useStore(state => state.getShoeStats);
 
@@ -91,7 +93,7 @@ const RetiredShoesReportScreen = ({ navigation }) => {
           />
           <StatsCard
             title="Total Distance"
-            value={`${stats.totalDistance.toFixed(0)} km`}
+            value={formatDistance(stats.totalDistance).formatted}
             icon="timeline"
             size="small"
           />
@@ -106,7 +108,7 @@ const RetiredShoesReportScreen = ({ navigation }) => {
           />
           <StatsCard
             title="Avg. Distance"
-            value={`${stats.averageDistance} km`}
+            value={formatDistance(stats.averageDistance).formatted}
             icon="trending-up"
             size="small"
           />

--- a/src/screens/ShoeDetailScreen.js
+++ b/src/screens/ShoeDetailScreen.js
@@ -15,10 +15,12 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import StatsCard from '../components/StatsCard';
 import Button from '../components/ui/Button';
+import { useUnits } from '../hooks/useUnits'; // Import useUnits
 
 const ShoeDetailScreen = ({ route, navigation }) => {
   const { shoeId } = route.params;
   const theme = useTheme();
+  const { formatDistance } = useUnits(); // Call useUnits
   const [retirementReason, setRetirementReason] = useState('');
   const [showRetirementForm, setShowRetirementForm] = useState(false);
 
@@ -148,19 +150,22 @@ const ShoeDetailScreen = ({ route, navigation }) => {
         {/* CHANGED: Access stats properties directly from shoeWithDetails */}
         <StatsCard
           title="Total Distance"
-          value={`${(shoeWithDetails.totalDistance || 0).toFixed(1)} km`}
+          value={formatDistance(shoeWithDetails.totalDistance || 0).formatted}
           icon="directions-run"
         />
         <StatsCard title="Runs" value={shoeWithDetails.totalRuns || 0} icon="repeat" />
         {/* Ensure maxDistance is on shoeWithDetails */}
-        {shoeWithDetails.maxDistance > 0 && (
-          <StatsCard
-            title="Remaining"
-            value={`${Math.max(0, shoeWithDetails.maxDistance - (shoeWithDetails.totalDistance || 0)).toFixed(1)} km`}
-            subtitle={`of ${shoeWithDetails.maxDistance} km`}
-            icon="timeline"
-          />
-        )}
+        {shoeWithDetails.maxDistance > 0 && (() => {
+          const remainingDistance = Math.max(0, shoeWithDetails.maxDistance - (shoeWithDetails.totalDistance || 0));
+          return (
+            <StatsCard
+              title="Remaining"
+              value={formatDistance(remainingDistance).formatted}
+              subtitle={`of ${formatDistance(shoeWithDetails.maxDistance).formatted}`}
+              icon="timeline"
+            />
+          );
+        })()}
       </View>
 
       {/* Logic using shoeWithDetails.isActive */}
@@ -216,7 +221,7 @@ const ShoeDetailScreen = ({ route, navigation }) => {
               Max Distance:
             </Text>
             <Text style={[styles.detailValue, { color: theme.colors.text }]}>
-              {shoeWithDetails.maxDistance} km
+              {formatDistance(shoeWithDetails.maxDistance).formatted}
             </Text>
           </View>
         )}

--- a/src/screens/ShoeListScreen.js
+++ b/src/screens/ShoeListScreen.js
@@ -21,9 +21,11 @@ import FilterModal from '../components/FilterModal';
 import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
 import LoadingSkeleton from '../components/LoadingSkeleton';
+import { useUnits } from '../hooks/useUnits'; // Import useUnits
 
 const ShoeListScreen = ({ navigation }) => {
   const theme = useTheme();
+  const { formatDistance } = useUnits(); // Get formatDistance
   const shoes = useStore(state => state.shoes);
   const loading = useStore(state => state.isLoading);
   const error = useStore(state => state.error);
@@ -339,7 +341,7 @@ const ShoeListScreen = ({ navigation }) => {
         >
           <StatsCard
             title="Total Distance"
-            value={`${stats.totalDistance.toFixed(1)} km`}
+            value={formatDistance(stats.totalDistance).formatted} // Use formatDistance
             icon="directions-run"
             color={theme.colors.primary}
           />

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -96,37 +96,7 @@ export const createSettingsStore = (set, get) => ({
     return get().settings;
   },
 
-  // Helper methods
-  getFormattedPace: paceInSeconds => {
-    const { distanceUnit } = get().settings;
-    const unitDisplay = distanceUnit === 'km' ? '/km' : '/mi';
-
-    if (!paceInSeconds) return `--:--${unitDisplay}`;
-
-    const minutes = Math.floor(paceInSeconds / 60);
-    const seconds = Math.floor(paceInSeconds % 60);
-    return `${minutes}:${seconds.toString().padStart(2, '0')}${unitDisplay}`;
-  },
-
-  convertDistance: (value, toUnit = null) => {
-    const { distanceUnit } = get().settings;
-    const targetUnit = toUnit || distanceUnit;
-
-    if (distanceUnit === targetUnit) return value;
-
-    // Convert between km and mi
-    if (distanceUnit === 'km' && targetUnit === 'mi') {
-      return value * 0.621371; // km to mi
-    } else if (distanceUnit === 'mi' && targetUnit === 'km') {
-      return value * 1.60934; // mi to km
-    }
-
-    return value;
-  },
-
-  formatDistance: (value, unit = null) => {
-    const { distanceUnit } = get().settings;
-    const displayUnit = unit || distanceUnit;
-    return `${value.toFixed(2)} ${displayUnit}`;
-  },
+  // Helper methods (getFormattedPace, convertDistance, formatDistance) were found to be unused
+  // or redundant with useUnits/unitUtils.js and have been removed to avoid confusion and ensure
+  // unit handling consistency as per UNITS_README.md.
 });


### PR DESCRIPTION
- Integrated `useUnits` hook across multiple screens and components to correctly format distances and paces based on user's preference (km or miles).
- Affected areas include ActiveRunScreen (LapsDisplay, StatsDisplay), RunDetailScreen, RunLogScreen, HomeScreen, ShoeListItem, ShoeListScreen, ShoeDetailScreen, and RetiredShoesReportScreen.
- Updated filter logic in RunLogScreen to handle distance inputs and display based on selected units.
- Removed unused and redundant unit conversion/formatting helper methods from `settingsStore.js` to promote consistency with `useUnits`.
- Ensured that data is assumed to be stored in kilometers (and pace in seconds/km) and converted for display only, adhering to `UNITS_README.md` guidelines.